### PR TITLE
Adding an example for overriding a "random" key

### DIFF
--- a/docs/overrides.md
+++ b/docs/overrides.md
@@ -137,7 +137,7 @@ Here is an example of specifying dependencies:
 
 ### package.json keys
 
-You an add any `package.json` keys to the overrides section, and they will be added or override keys in the components `package.json`. The following keys cannot be modified:
+You an add any `package.json` keys to the overrides section, and they will be added or override keys in the components `package.json`. This is useful when you want to extend a component with a unique functionality, for example - adding a `bin` key to a component (creating an executable component). The following keys cannot be modified:
 
 - name
 - version


### PR DESCRIPTION
it seemed to me that there was an example lacking when explaining that (almost) every key can be overridden. i've added a basic example.
i don't feel the need to show a complete json, but this is also a possibility.

