### PR TITLE
Fix bit remove command when removing from remote

### DIFF
--- a/docs/removing-components.md
+++ b/docs/removing-components.md
@@ -12,7 +12,7 @@ Each collection has an internal cache for its dependencies. But this does not me
 To remove a component from a remote Collection, specify the full component ID.
 
 ```bash
-$ bit remove username.your-collection/foo/bar
+$ bit remove username.your-collection/foo/bar --remote
 successfully removed components:
 username.your-collection/foo/bar
 ```


### PR DESCRIPTION
In [this page](https://docs.bit.dev/docs/removing-components#remove-a-component-from-a-remote-collection) the command for removing from remote is wrong as it's missing the `--remote` option