### PR TITLE
Fix typo in Components > Installing documentation

### DIFF
--- a/docs/installing-components.md
+++ b/docs/installing-components.md
@@ -7,7 +7,7 @@ Bit supports CommonJS API for consuming components as packages.
 
 To install components with npm or yarn we first need to configure `@bit` as a [scoped registry](https://docs.npmjs.com/misc/scope#associating-a-scope-with-a-registry). Bit does it by default as part of the `bit login` process.
 
-To configure the registry manully, use the `npm config` command.
+To configure the registry manually, use the `npm config` command.
 
 ```bash
 npm config set '@bit:registry' https://node.bit.dev


### PR DESCRIPTION
Simply fixes a typo I noticed in the documentation. "manully" should be "manually". Everything else in this section looks good, but I haven't tested all of the cli commands listed on this page.