### PR TITLE
Github actions

### DIFF
--- a/docs/ci.md
+++ b/docs/ci.md
@@ -136,6 +136,22 @@ In `.gitlab-ci.yml` run the script that [generates the file for the user](#gener
 
 Add the BIT_TOKEN as [environment variable](https://docs.gitlab.com/ee/ci/variables/)
 
+### Github actions
+
+Add the BIT_TOKEN as a [secret](https://help.github.com/en/actions/configuring-and-managing-workflows/creating-and-storing-encrypted-secrets) in Github.
+
+In the Github workflow file create a step before npm install section:
+```bash 
+- name: init bit.dev
+  run: |
+    echo "Adding bit.dev to npm registry"
+    npm config set @bit:registry https://node.bit.dev
+    npm config set //node.bit.dev/:_authToken ${BIT_TOKEN}
+    echo "Completed adding bit.dev to npm registry"
+  env:
+    BIT_TOKEN: ${{ secrets.BIT_TOKEN }}
+```
+
 ### Heroku
 
 To generate npmrc before installing dependencies, run a pre build script as described [here](https://devcenter.heroku.com/articles/nodejs-support#heroku-specific-build-steps).


### PR DESCRIPTION
Initially in my Github workflow bit-step I had:

```
echo "@bit:registry=https://node.bit.dev" >> ~/.npmrc
echo "//node.bit.dev/:_authToken=${BIT_TOKEN}" >> ~/.npmrc
```
but it didn't work everywhere. I was getting an error:
npm ERR! 404  '@bit/YourComponent' is not in the npm registry. 
so I had to change it to
```
npm config set @bit:registry https://node.bit.dev
npm config set //node.bit.dev/:_authToken ${BIT_TOKEN}
```