### PR TITLE
fix typo in harmony components docs

### DIFF
--- a/docs/components/components/namespaces.md
+++ b/docs/components/components/namespaces.md
@@ -7,4 +7,4 @@ Namespaces serve as folders that organize components in the Workspace or inside 
 
 To namespace a component us the `--namespace` or `-n` option.
 
-Specifying a namespace helps you you organize your components and lets you perform actions on multiple components at once. Namespaces are also useful in specifying overriding rules for all components under a specific namespace.
+Specifying a namespace helps you organize your components and lets you perform actions on multiple components at once. Namespaces are also useful in specifying overriding rules for all components under a specific namespace.


### PR DESCRIPTION
The title is self-explanatory 🙂