### PR TITLE
Small markdown fix

### DIFF
--- a/docs/getting-started/initializing-workspace.md
+++ b/docs/getting-started/initializing-workspace.md
@@ -46,6 +46,7 @@ bit install
 ## Created Files
 
 <FilesBitCreates />
+
 ## What's Next
 
 Once you have initialized a workspace, you can start [creating components](creating-components).


### PR DESCRIPTION
Needed to add a space to fix a heading not rendering properly. See on [this page](https://harmony-docs.bit.dev/getting-started/initializing-workspace#committing-to-git).

<img width="997" alt="Screen Shot 2021-05-12 at 9 10 31 am" src="https://user-images.githubusercontent.com/75279359/117895691-3ecf1f80-b302-11eb-9700-5d315674cd16.png">

