### PR TITLE
publishing is actually the pkg doc

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -132,7 +132,7 @@ module.exports = {
             'building-with-bit/testing-components',
             'building-with-bit/compiling-components',
             'building-with-bit/exporting-components',
-            'building-with-bit/publishing-components',
+            //'building-with-bit/publishing-components',
             'building-with-bit/versioning-components',
             'building-with-bit/importing-components',
             'building-with-bit/installing-components'

--- a/static/_redirects
+++ b/static/_redirects
@@ -98,3 +98,5 @@
 /open-source/open-source  /resources/community
 
 /reference/authentication /bit-dot-dev/authentication
+
+/building-with-bit/publishing-components /aspects/pkg


### PR DESCRIPTION
removed "publishing components"
added redirect to the pkg aspect