### PR TITLE
add bit compile to quick guide docs

### DIFF
--- a/docs/getting-started/creating-components.mdx
+++ b/docs/getting-started/creating-components.mdx
@@ -39,7 +39,7 @@ bit create react-component-js ui/button  # JavaScript
 bit install @testing-library/react
 ```
 
-3. Compile and then Start the dev server
+3. Compile and then start the dev server
 
 ```bash
 bit compile

--- a/docs/getting-started/creating-components.mdx
+++ b/docs/getting-started/creating-components.mdx
@@ -39,9 +39,10 @@ bit create react-component-js ui/button  # JavaScript
 bit install @testing-library/react
 ```
 
-3. Start the dev server
+3. Compile and then Start the dev server
 
 ```bash
+bit compile
 bit start
 ```
 


### PR DESCRIPTION
Right now the docs in the getting started / Creating components section gives errors when following the instructions. As I was following the guide, I got `module not found` errors, and when I visited Slack I found a change was made to bit, where now is needed to run `bit compile` before running `bit start`.

This change is made so that the docs include that new step in the **Quick Guide**. This and pull request #219 should fix the issue.

