### PR TITLE
add bit compile to starting dev server docs

### DIFF
--- a/docs/components/workspace/starting-dev-server.md
+++ b/docs/components/workspace/starting-dev-server.md
@@ -3,9 +3,15 @@ id: starting-dev-server
 title: Starting the Dev Server
 ---
 
-The start command starts our dev server, compiles our component and watches for changes using Hot Module Replacement. It runs different workspace tasks through workers, such as testing, linters and any workspace tasks that are defined by the component.
+The start command starts our dev server, and watches for changes using Hot Module Replacement. It runs different workspace tasks through workers, such as testing, linters and any workspace tasks that are defined by the component.
+
+:::note Compile Components
+
+If you created or added a new component, you will need to compile before running the server. If you are following along this guide, you should run `bit compile` to compile your newly created components.
+:::
 
 ```bash
+bit compile
 bit start
 ```
 


### PR DESCRIPTION
Right now the docs in the getting started / Creating components section gives errors when following the instructions. As I was following the guide, I got `module not found` errors, and when I visited Slack I found a change was made to bit, where now is needed to run `bit compile` before running bit start.

This change is made so that the docs include that new step in the `starting-dev-server.md` file, so the update is made to the docs. This pull request, alongside #218 should fix this issue.

