### PR TITLE
Fix wrong install command

### DIFF
--- a/docs/components/install/install-components.md
+++ b/docs/components/install/install-components.md
@@ -19,14 +19,14 @@ values={[
 <TabItem value="NPM">
 
 ```bash
-npm install @YourUserName/componentScopeName.componentID
+npm install @bit/YourUserName.componentScopeName.componentID
 ```
 
   </TabItem>
   <TabItem value="Yarn">
 
 ```bash
-yarn add @YourUserName/componentScopeName.componentID
+yarn add @bit/YourUserName.componentScopeName.componentID
 ```
 
   </TabItem>


### PR DESCRIPTION
The install command is wrong, what makes the user receive a 404 error when he tries to do an npm install.

For reference, look on https://bit-dev-community.slack.com/archives/CCDHG0TPY/p1629484402248100

There is nothing on CONTRIBUTING.md, so, feel free to change anything on it or discard this PR.