### PR TITLE
Fixed typo to avoid confusion in Initalizing workspace page

### DIFF
--- a/docs/getting-started/initializing-workspace.md
+++ b/docs/getting-started/initializing-workspace.md
@@ -26,7 +26,7 @@ bit new react <my-workspace-name>
 
 ```bash
 cd <my-workspace-name>
-bit install
+bit start
 ```
 
 ---


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/25435795/151936976-44d896bf-d43a-461d-9954-46f147a7c478.png)

Now:
![image](https://user-images.githubusercontent.com/25435795/151936908-0af2c3b9-98ee-46aa-9c5c-e857b9308ee7.png)
