### PR TITLE
fix example error in mdx page

### DIFF
--- a/docs/aspects/mdx/mdx.mdx
+++ b/docs/aspects/mdx/mdx.mdx
@@ -31,7 +31,7 @@ import { LoginForm } from './login-form'
 A simple example of live example:
 
 ```jsx live=true
-<LoginForm><LoginForm/>
+<LoginForm />
 ```
 ````
 


### PR DESCRIPTION
Hello,

In the MDX page, there was an error on the first live example. The LoginForm component was not used correctly. 

